### PR TITLE
Add channel load effects

### DIFF
--- a/monitor_sim.py
+++ b/monitor_sim.py
@@ -26,11 +26,11 @@ class MonitoringSimulation(simple_sim.Simulation):
 
     # переопределяем пересылку чтобы учитывать потерянные пакеты
     def _forward(self, pkt, ch):
-        if ch.is_lost():
+        if ch.is_lost() or ch._queue_overflow(self.now):
             self.lost += 1
             self.bin_lost += 1
             return
-        delay = ch.transmit_delay()
+        delay = ch.transmit_delay(self.now)
         self.schedule(self.now + delay, 0, lambda: self._on_delivered(pkt, delay))
 
     # доставка пакета — считаем задержку


### PR DESCRIPTION
## Summary
- allow setting per-channel capacity and queue
- drop packets when channel queue is full
- account for queuing delay in delivery time
- update monitor simulation to support new channel model

## Testing
- `python simple_sim.py`
- `python monitor_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685f48e7774c832cad6af5fed31609cd