### PR TITLE
Add call loss modeling

### DIFF
--- a/metrics.csv
+++ b/metrics.csv
@@ -1,2 +1,2 @@
-total_sent,delivered,lost,loss_rate,avg_delay_ms,delay_var
-293,288,5,0.017065,2.002,-0.000
+total_sent,delivered,lost,loss_rate,avg_delay_ms,delay_var,call_attempts,call_failures,call_loss_rate
+307,305,2,0.006515,2.002,-0.000,7,1,0.142857

--- a/monitor_sim.py
+++ b/monitor_sim.py
@@ -61,13 +61,17 @@ class MonitoringSimulation(simple_sim.Simulation):
 def main():
     n0 = simple_sim.Node(0, 55.751244, 37.618423)      # Москва
     n1 = simple_sim.Node(1, 59.93106, 30.36057)        # Санкт-Петербург
-    ch = simple_sim.Channel(n0, n1, extra_delay_ms=2.0, loss_prob=0.01)
+    ch = simple_sim.Channel(n0, n1,
+                           extra_delay_ms=2.0,
+                           loss_prob=0.01,
+                           call_loss_prob=0.05)
 
     sim = MonitoringSimulation([n0, n1],
                                {(0, 1): ch},
                                end_time_ms=30_000.0,   # 30 с
                                bin_ms=1000)            # шаг 1 с
     simple_sim.PoissonGenerator(rate_pps=10, src=n0, dst=n1, sim=sim)
+    simple_sim.CallGenerator(rate_cps=0.2, src=n0, dst=n1, sim=sim)
     sim.run()                                          # запуск модели
 
     # ── визуализация ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- extend Channel to model call losses
- support call loss events in Simulation and new CallGenerator
- export call metrics to CSV
- demonstrate call loss modeling in both simulation scripts

## Testing
- `python simple_sim.py`
- `python monitor_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685f4b094d68832ca974f8db679cde4d